### PR TITLE
Support for include and skip directives on fields

### DIFF
--- a/src/query-to-decoder.ts
+++ b/src/query-to-decoder.ts
@@ -191,7 +191,16 @@ export function decoderFor(def: OperationDefinition | FragmentDefinition, info: 
 
     let info_type = info.getType()
     let isMaybe = false
-    if (info_type instanceof GraphQLNonNull) {
+
+    let include = field.directives.reduce((acc, {name, arguments: [argument]}) => {
+      if (name.value === "include" && !argument.value.value) {
+        return argument.value.value;
+      } else {
+        return acc;
+      }
+    }, true);
+
+    if (info_type instanceof GraphQLNonNull && include) {
       info_type = info_type['ofType'];
     } else {
       isMaybe = true;
@@ -211,9 +220,9 @@ export function decoderFor(def: OperationDefinition | FragmentDefinition, info: 
       prefix = 'list ';
     }
 
-      if (info_type instanceof GraphQLNonNull) {
-        info_type = info_type['ofType'];
-      }
+    if (info_type instanceof GraphQLNonNull) {
+      info_type = info_type['ofType'];
+    }
 
     if (info_type instanceof GraphQLUnionType) {
       // Union

--- a/src/query-to-decoder.ts
+++ b/src/query-to-decoder.ts
@@ -194,7 +194,9 @@ export function decoderFor(def: OperationDefinition | FragmentDefinition, info: 
 
     let include = field.directives.reduce((acc, {name, arguments: [argument]}) => {
       if (name.value === "include" && !argument.value.value) {
-        return argument.value.value;
+        return false;
+      } else if (name.value === "skip" && argument.value.value) {
+        return false;
       } else {
         return acc;
       }

--- a/src/query-to-decoder.ts
+++ b/src/query-to-decoder.ts
@@ -242,12 +242,15 @@ export function decoderFor(def: OperationDefinition | FragmentDefinition, info: 
         let right = '(map ' + shape + ' ' + fields.expr + '))';
         let indent = '        ';
         if (prefix) {
-          left =  '(map (Maybe.withDefault []) (maybe' + left;
+          left = '(map (Maybe.withDefault []) (maybe' + left;
           right = '(' + prefix + right + ')))';
-        }
-        if (isMaybe) {
+        } else if (isMaybe) {
           right = '(' + 'maybe ' + right + ')';
+        } else if (!include && !(info_type instanceof GraphQLList)) {
+          left = '(maybe' + left;
+          right = right + ')';
         }
+
 
         return { expr: left + indent + right };
 

--- a/src/query-to-decoder.ts
+++ b/src/query-to-decoder.ts
@@ -228,6 +228,7 @@ export function decoderFor(def: OperationDefinition | FragmentDefinition, info: 
 
     // Union
     if (info_type instanceof GraphQLUnionType) {
+
       let expr = walkUnion(originalName, field, info);
       return expr;
 

--- a/src/query-to-elm.ts
+++ b/src/query-to-elm.ts
@@ -641,7 +641,9 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
     // todo: Directives
     let include = field.directives.reduce((acc, {name, arguments: [argument]}) => {
       if (name.value === "include" && !argument.value.value) {
-        return argument.value.value;
+        return false;
+      } else if (name.value === "skip" && argument.value.value) {
+        return false;
       } else {
         return acc;
       }

--- a/src/query-to-elm.ts
+++ b/src/query-to-elm.ts
@@ -84,6 +84,7 @@ export function queryToElm(graphql: string, moduleName: string, liveUrl: string,
     'Json.Encode exposing (encode)',
     'Time',
     'Http',
+    'Maybe',
     importGraphql
   ], decls);
 }
@@ -652,7 +653,7 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
     // SelectionSet
     if (field.selectionSet) {
       let isMaybe = false;
-      if (info_type instanceof GraphQLNonNull && include) {
+      if (info_type instanceof GraphQLNonNull) {
         info_type = info_type['ofType'];
       } else {
         isMaybe = true;
@@ -684,7 +685,7 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
         throw new Error('Unknown GraphQL field: ' + field.name.value);
       }
       let type = typeToElm(info.getType());
-      if (!include) {
+      if (!include && !(info_type instanceof GraphQLList)) {
         type = new ElmTypeApp('Maybe', [type]);
       }
       info.leave(field);

--- a/src/query-to-elm.ts
+++ b/src/query-to-elm.ts
@@ -661,6 +661,10 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
 
       let isList = info_type instanceof GraphQLList;
 
+      if (!include && !isList) {
+        isMaybe = true;
+      }
+
       let [fields, spreads, union] = walkSelectionSet(field.selectionSet, info);
       
       let type: ElmType = union ? union : new ElmTypeRecord(fields);

--- a/src/query-to-elm.ts
+++ b/src/query-to-elm.ts
@@ -628,7 +628,7 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
   function walkField(field: Field, info: TypeInfo): ElmFieldDecl {
     info.enter(field);
 
-    let info_type = info.getType()
+    let info_type = info.getType();
     // Name
     let name = elmSafeName(field.name.value);
     // Alias
@@ -649,11 +649,11 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
 
     // SelectionSet
     if (field.selectionSet) {
-      let isMaybe = false
+      let isMaybe = false;
       if (info_type instanceof GraphQLNonNull && include) {
-	    info_type = info_type['ofType']
+        info_type = info_type['ofType'];
       } else {
-	    isMaybe = true
+        isMaybe = true;
       }
 
       let isList = info_type instanceof GraphQLList;
@@ -672,11 +672,11 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
       }
 
       if (isMaybe) {
-	    type = new ElmTypeApp('Maybe', [type]);
+        type = new ElmTypeApp('Maybe', [type]);
       }
 
       info.leave(field);
-      return new ElmFieldDecl(name, type)
+      return new ElmFieldDecl(name, type);
     } else {
       if (!info.getType()) {
         throw new Error('Unknown GraphQL field: ' + field.name.value);
@@ -686,7 +686,7 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema, verb:
         type = new ElmTypeApp('Maybe', [type]);
       }
       info.leave(field);
-      return new ElmFieldDecl(name, type)
+      return new ElmFieldDecl(name, type);
     }
   }
   return walkQueryDocument(doc, new TypeInfo(schema));


### PR DESCRIPTION
## Summary of the major changes in this PR:
- Update: added support for the include directive on fields
- Update: added support for the skip directive on fields
- Update: when using the skip/include directives on a list type, and when decoding any list type, the resulting type will always be a list
- Update: made changes so that the skip/include directives will apply to objects with selected fields